### PR TITLE
Rename workflows and event names to reduce ambiguity

### DIFF
--- a/.github/workflows/company3-e2e.yml
+++ b/.github/workflows/company3-e2e.yml
@@ -1,4 +1,4 @@
-name: E2E Testing
+name: Company 3 E2E Testing
 
 on:
   push:
@@ -7,9 +7,9 @@ on:
     branches: [main]
   repository_dispatch:
     types: 
-      - algorithm-1
-      - algorithm-2
-      - backend
+      - company3-algorithm-1
+      - company3-algorithm-2
+      - company3-backend
 
 # Make sure URLs defined here correspond with ports defined below
 env:

--- a/.github/workflows/company4-e2e.yml
+++ b/.github/workflows/company4-e2e.yml
@@ -1,4 +1,4 @@
-name: E2E Testing
+name: Company 4 E2E Testing
 
 on:
   push: 


### PR DESCRIPTION
# GraphQL Schema Change Request
N/A

## General Comments

### Why

To make it visible that workflow runs are from company 3 or company 4.
