### PR TITLE
Aomi/feat/generate full year schedule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@ algorithm2/ @SENG499-S22-Company3/algorithm-2
 
 # Backend
 
-graphql/ @SENG499-S22-Company3/backend @szeckirjr @keithradford @rcrossf @a-mon @peterrwilson99
+graphql/ @SENG499-S22-Company3/backend  @keithradford 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -146,7 +146,9 @@ input CoursePreferenceInput {
 input GenerateScheduleInput {
   year: Int!
   term: Term!
-  courses: [CourseInput!]
+  fallCourses: [CourseInput!]
+  springCourses: [CourseInput!]
+  summerCourses: [CourseInput!]
   algorithm1: Company!
   algorithm2: Company!
 }


### PR DESCRIPTION
# GraphQL Schema Change Request

1. Update the [Google Document](https://docs.google.com/document/d/1x6KEY6Kw-w27Hrgs4ZayMnQelcrhUBcx4dytABuLY2k/edit) to reflect the changes in the GraphQL schema.
2. Make the schema changes.
3. Receive approval from backend of company 3 and company 4.
4. Merge changes and ping backend and frontend from companies.

## General Comments

### Why
As an admin user, I want to be able to generate an entire years schedule rather than just by a single term. This is a crucial piece of the last sprints goals for company 3.

### Stakeholders

- [ ] Company 1
  - [ ] Backend
  - [ ] Frontend
  - [ ] Algorithm 1
  - [ ] Algorithm 2
- [ ] Company 2
  - [ ] Backend
  - [ ] Frontend
  - [ ] Algorithm 1
  - [ ] Algorithm 2
 
## Notes
Frontend teams, please check if the existing schedule query is sufficient to handle these new changes. We should modify the schedule query as needed to make this new feature easier to handle on the frontend.
