### PR TITLE
feat: add semester course prefs

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -116,6 +116,18 @@ input CreateTeachingPreferenceInput {
   reliefReason: String
   hasTopic: Boolean!
   topicDescription: String
+  """
+  Number of courses a professor prefers to teach in the FALL semester. Defaults to 1.
+  """
+  fallTermCourses: Int
+  """
+  Number of courses a professor prefers to teach in the SPRING semester. Defaults to 1.
+  """
+  springTermCourses: Int
+  """
+  Number of courses a professor prefers to teach in the SUMMER semester. Defaults to 1.
+  """
+  summerTermCourses: Int
 }
 
 type TeachingPreferenceSurvey {


### PR DESCRIPTION
# GraphQL Schema Change Request

1. Update the [Google Document](https://docs.google.com/document/d/1x6KEY6Kw-w27Hrgs4ZayMnQelcrhUBcx4dytABuLY2k/edit) to reflect the changes in the GraphQL schema.
2. Make the schema changes.
3. Receive approval from backend of company 3 and company 4.
4. Merge changes and ping backend and frontend from companies.

## General Comments

### Why

> All of type int. Basically these are the preferred max number of courses a prof wants to teach a semester.
As such, values of 0 makes sure a prof will not be scheduled in a given term. Defaults to 1 otherwise.

### Stakeholders

- [ ] Company 1
  - [ ] Backend
  - [x] Frontend
  - [ ] Algorithm 1
  - [ ] Algorithm 2
- [ ] Company 2
  - [ ] Backend
  - [ ] Frontend
  - [ ] Algorithm 1
  - [ ] Algorithm 2
